### PR TITLE
Improve Virtual-IP-for-vCenter documentation clarity and formatting

### DIFF
--- a/drafts/Virtual-IP-for-vCenter.md
+++ b/drafts/Virtual-IP-for-vCenter.md
@@ -6,7 +6,7 @@ As documented in [Designated IP ranges for Arc resource bridge](https://learn.mi
 
 ## Solution Approach
 
-To avoid such overlapping IP addresses between Azure Arc resource bridge and vCenter Server, we can use a virtual/intermidiate IP address for the vCenter, which is outside the `10.244.*` range.
+To avoid such overlapping IP addresses between Azure Arc resource bridge and vCenter Server, we can use a virtual/intermidiate IP address for the vCenter Server, which is outside the `10.244.*` range.
 
 High level design will look like below.
 ![design](assets/arc-rb.png)

--- a/drafts/Virtual-IP-for-vCenter.md
+++ b/drafts/Virtual-IP-for-vCenter.md
@@ -2,7 +2,7 @@
 
 ### Context
 
-As documented in (Designated IP ranges for Arc resource bridge)[https://learn.microsoft.com/azure/azure-arc/resource-bridge/network-requirements#designated-ip-ranges-for-arc-resource-bridge], IP address `10.244.0.0/16` is reserved internally. If customers are using address space which includes this reserved IP address as a AVS private cloud address (e.g. `10.244.0.0/22`) then network traffic originating from Arc resource bridge towards AVS vCenter Server will fail. This behaviour is caused due to appliance VM treating `10.244.0.2` is an address inside the pod network, and the traffic could not be routed out of the appliance VM.
+As documented in [Designated IP ranges for Arc resource bridge](https://learn.microsoft.com/azure/azure-arc/resource-bridge/network-requirements#designated-ip-ranges-for-arc-resource-bridge), IP address `10.244.0.0/16` is reserved internally. If customers are using address space which includes this reserved IP address as a AVS private cloud address (e.g. `10.244.0.0/22`) then network traffic originating from Arc resource bridge towards AVS vCenter Server will fail. This behaviour is caused due to appliance VM treating `10.244.0.2` is an address inside the pod network, and the traffic could not be routed out of the appliance VM.
 
 ## Solution Approach
 


### PR DESCRIPTION
Enhance the documentation by fixing link formatting and clarifying wording related to the vCenter Server.