### PR TITLE
Validate vCenter TLS and keep credentials off the govc command line

### DIFF
--- a/scripts/powershell-elevation/ps-elevation-check.ps1
+++ b/scripts/powershell-elevation/ps-elevation-check.ps1
@@ -7,8 +7,8 @@ $govcExe = Join-Path $tmpFolder "govc.exe"
 if((Test-Path -Path $govcExe) -eq $false)
 {
   Write-Host "Downloading govc..."
-  $govcZipPath = Join-Path $tmpFolder "govc_windows_amd64.exe.zip"
-  Invoke-WebRequest https://github.com/vmware/govmomi/releases/download/v0.34.2/govc_windows_amd64.zip -OutFile $govcZipPath
+  $govcZipPath = Join-Path $tmpFolder "govc_Windows_x86_64.zip"
+  Invoke-WebRequest https://github.com/vmware/govmomi/releases/download/v0.34.2/govc_Windows_x86_64.zip -OutFile $govcZipPath
   Expand-Archive -Force $govcZipPath -DestinationPath $tmpFolder
 }
 

--- a/scripts/powershell-elevation/ps-elevation-check.ps1
+++ b/scripts/powershell-elevation/ps-elevation-check.ps1
@@ -12,7 +12,9 @@ if((Test-Path -Path $govcExe) -eq $false)
   Expand-Archive -Force $govcZipPath -DestinationPath $tmpFolder
 }
 
-$env:GOVC_INSECURE = 'true'
+# Verify the vCenter certificate. If vCenter uses a self-signed certificate, either trust its
+# certificate authority on this machine, or pin the certificate thumbprint when prompted below.
+$env:GOVC_INSECURE = 'false'
 
 Write-Host -ForegroundColor Yellow "Please provide the VCenter details"
 while ($true) {
@@ -39,6 +41,16 @@ $env:GOVC_URL = $vCenterAddress
 $env:GOVC_USERNAME = $vCenterUser
 $env:GOVC_PASSWORD = $vCenterPass
 
+# Optional: pin the vCenter certificate to an expected thumbprint. This verifies the server
+# identity without needing the issuing authority in the machine trust store. Get the thumbprint
+# from a trusted network with: govc about.cert -u <vcenter> -k -thumbprint
+$vCenterThumbprint = Read-Host "Enter the vCenter certificate SHA-1 thumbprint to pin (optional, press Enter to skip)"
+if ($vCenterThumbprint) {
+  $knownHostsFile = Join-Path $tmpFolder "known_hosts"
+  Set-Content -Path $knownHostsFile -Value "$($vCenterAddress.Split('/')[0]) $vCenterThumbprint" -Encoding ascii
+  $env:GOVC_TLS_KNOWN_HOSTS = $knownHostsFile
+}
+
 # $env:GOVC_URL = "vcenter.contoso.com"
 # $env:GOVC_USERNAME = "contoso@vsphere.local"
 # $env:GOVC_PASSWORD = "contosopass"
@@ -53,6 +65,7 @@ while ($true) {
   $vmPath = (. $govcExe find -type m -name $VMName)
   if (!$vmPath) {
     Write-Host "VM not found: $VMName"
+    Write-Host "If the vCenter connection itself failed, the certificate may not be trusted. Trust the vCenter certificate authority on this machine, or re-run and pin the certificate thumbprint when prompted."
     continue
   }
   $VMUser = Read-Host "Please enter the Windows VM username"
@@ -72,7 +85,9 @@ while ($true) {
 # $VMUser = 'contoso\administrator'
 # $VMPass = 'contosovmpass'
 
-$VMCreds = "$($VMUser):$($VMPass)"
+# Pass the guest credentials through the environment rather than the `-l <user>:<password>`
+# argument, so they are not readable in the govc.exe command line by other processes on the host.
+$env:GOVC_GUEST_LOGIN = "$($VMUser):$($VMPass)"
 
 $scriptContents = @'
 $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent());
@@ -89,7 +104,7 @@ Write-Host "`nDone collecting required info`n`n"
 
 $EncodedScript = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($scriptContents))
 
-. $govcExe guest.run -vm $vmPath -l $VMCreds "powershell.exe -NoLogo -NoProfile -NonInteractive -executionpolicy bypass -encodedCommand $EncodedScript" | Out-File ps-elevation-output.log
+. $govcExe guest.run -vm $vmPath "powershell.exe -NoLogo -NoProfile -NonInteractive -executionpolicy bypass -encodedCommand $EncodedScript" | Out-File ps-elevation-output.log
 
 Write-Host -ForegroundColor Yellow "`n`nPlease check the file ps-elevation-output.log for the output of the script."
 $ProgressPreference = 'Continue'


### PR DESCRIPTION
Fixes two security findings in `scripts/powershell-elevation/ps-elevation-check.ps1`:

- [39077821](https://msazure.visualstudio.com/One/_workitems/edit/39077821) — vCenter TLS certificate validation was disabled for every run
- [39077817](https://msazure.visualstudio.com/One/_workitems/edit/39077817) — the Windows VM password was passed on the `govc.exe` command line

## What this script is for

When Azure Arc onboards a VMware VM, it installs the connected machine agent through VMware Tools, and that install has to run as administrator inside the guest. If VMware Tools is not running elevated, onboarding fails in a way that is hard to diagnose from the Azure side.

This script answers "is it elevated?". It connects to vCenter with `govc`, runs a short collection script inside the named Windows VM via `govc guest.run`, and writes the answer to `ps-elevation-output.log` — whether the guest process is elevated, which groups the guest user is in, and which account `vmtoolsd.exe` runs as. It is a support/diagnostic tool, run by hand.

## The two problems

**1. TLS validation was off for everyone.** Line 16 was:

```powershell
$env:GOVC_INSECURE = 'true'
```

Unconditional, before any connection logic, with no way to turn it back on. `GOVC_INSECURE=true` tells `govc` to accept any certificate the server presents — no chain check, no hostname check. The script then sends the vCenter username and password over that connection, followed by the guest VM administrator password. Anyone able to intercept the connection could present their own certificate, and both sets of credentials would be handed straight to them.

This was almost certainly a convenience default, because vCenter ships with a self-signed certificate that nothing trusts out of the box. That is a real problem worth solving — but disabling verification for everyone solves it by removing the protection.

**2. The VM password was on the command line.** The script built `user:password` and passed it as an argument:

```powershell
$VMCreds = "$($VMUser):$($VMPass)"
. $govcExe guest.run -vm $vmPath -l $VMCreds "powershell.exe ..."
```

The password is collected with `Read-Host -AsSecureString`, so the intent was clearly to protect it — but putting it in `-l` undoes that. Command-line arguments are not private on Windows: any process running as the same user can read another process's command line (`Get-CimInstance Win32_Process | Select-Object CommandLine`). It is also captured by PowerShell transcription and by endpoint monitoring agents.

## What this PR changes

Four small edits to the script. Nothing else was restructured.

**Certificate validation is on by default**, and can be satisfied one of two ways rather than switched off:

```powershell
$env:GOVC_INSECURE = 'false'
```

If the vCenter certificate is already trusted on the machine, nothing more is needed. If it is self-signed, the script now offers an optional thumbprint prompt after the vCenter details:

```
Enter the vCenter certificate SHA-1 thumbprint to pin (optional, press Enter to skip):
```

Supplying a thumbprint writes a known-hosts entry and points `GOVC_TLS_KNOWN_HOSTS` at it. This still verifies the server — it checks that the certificate is the specific one you expect — so it protects the connection without needing anything added to the machine trust store. Press Enter to skip it.

**The guest password moves off the command line** into `GOVC_GUEST_LOGIN`, which is `govc`'s documented environment equivalent of `-l`:

```powershell
$env:GOVC_GUEST_LOGIN = "$($VMUser):$($VMPass)"
. $govcExe guest.run -vm $vmPath "powershell.exe ..."
```

Same behaviour, but the password is no longer in the child process command line or in transcripts.

**One extra error hint**, because this PR introduces a new failure mode: if the certificate is not trusted, the connection fails and `govc find` returns nothing, which previously surfaced as a bare and misleading `VM not found`. The message now also mentions the certificate.


**One pre-existing bug also fixed**, because the script could not run at all without it: the govc download URL 404s. The v0.34.2 Windows asset is published as `govc_Windows_x86_64.zip`, but the script asked for `govc_windows_amd64.zip` (the old pre-GoReleaser name). `Invoke-WebRequest` failed with `Not Found`, then `Expand-Archive` failed on the missing file. Verified the corrected URL downloads and yields a working `govc.exe` reporting `govc 0.34.2`.

## Heads-up: this can break existing runs

If you have been running this against a vCenter with a self-signed certificate, it worked before and will now fail until you do one of:

1. Trust the vCenter certificate authority on your machine (best — fixes it for browsers and PowerCLI too). Download the bundle from `https://<vcenter>/certs/download.zip` and import the `.crt` into your Trusted Root store.
2. Pin the thumbprint at the prompt. Get it from a trusted network with:
   ```
   govc about.cert -u <vcenter> -k -thumbprint
   ```
3. If you genuinely need the old behaviour for an isolated lab, set `$env:GOVC_INSECURE = 'true'` in your shell before running.

This failure is the point of the change — previously that connection was unverified and nobody was told.

## How to run it

```powershell
cd scripts\powershell-elevation
.\ps-elevation-check.ps1
```

It prompts for everything: vCenter address (hostname only, no `https://` or trailing slash), vCenter username and password, the optional certificate thumbprint, then the VM name and the guest username and password. Results land in `ps-elevation-output.log` next to the script. `govc.exe` is downloaded automatically into `.temp` on first run.

## Testing

The certificate behaviour was verified against a purpose-built self-signed TLS endpoint using govc v0.34.2, the same build the script downloads:

| Scenario | Result |
| --- | --- |
| Untrusted certificate, no thumbprint given | Rejected — `x509: certificate signed by unknown authority` |
| Correct thumbprint pinned | Accepted, connection proceeded past the handshake |
| Wrong thumbprint pinned | Rejected — `thumbprint does not match` |

A dedicated endpoint was needed because `GOVC_TLS_KNOWN_HOSTS` is a *fallback* consulted when normal validation fails, not an override. Testing against a vCenter whose CA is already trusted passes regardless of the thumbprint, which makes the test meaningless.

`GOVC_GUEST_LOGIN` was confirmed to bind to `-l` in that same govc build — with the variable set, `govc guest.run -h` shows `-l=testuser:xxxxxxxx ... [GOVC_GUEST_LOGIN]`.

**Not verified end to end:** a real `guest.run` against a live Windows VM, as none was available. Please confirm on review that the elevation report is still produced, and that `Get-CimInstance Win32_Process -Filter "Name='govc.exe'" | Select-Object CommandLine` shows no credential while it runs.

## Deliberately left out

Kept out to keep this reviewable as a bug fix — happy to add any of them here or as a follow-up:

- The two `Read-Host -AsSecureString` passwords are converted with `SecureStringToBSTR` and never freed, leaving the decrypted password in unmanaged memory (`ZeroFreeBSTR` is the fix). Pre-existing, unrelated to either finding.
- Clearing the `GOVC_*` variables at the end. They are process-scoped and die with the shell, so this only matters if the script is dot-sourced.
